### PR TITLE
W-22435426: Add a skill to the example app to help with using our ope…

### DIFF
--- a/examples/Shared/Voice/VoiceControlPanel.swift
+++ b/examples/Shared/Voice/VoiceControlPanel.swift
@@ -46,7 +46,7 @@ struct VoiceControlPanel: View {
                 compactLayout
             }
         }
-        .onChange(of: multimediaClient.session.state) { _, newValue in
+        .onChange(of: multimediaClient.session.state) { newValue in
             handleStateChange(newValue)
         }
         .onAppear { handleStateChange(multimediaClient.session.state) }

--- a/examples/Shared/Voice/VoiceModalityObserver.swift
+++ b/examples/Shared/Voice/VoiceModalityObserver.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import Combine
 import SMIClientCore
 import SMIMultimediaCommon
 

--- a/examples/Shared/Voice/VoiceTranscriptFeedView.swift
+++ b/examples/Shared/Voice/VoiceTranscriptFeedView.swift
@@ -100,7 +100,7 @@ private struct VoiceTranscriptEntryView: View {
             .font(.headline)
             .lineSpacing(Constants.lineSpacing)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .onChange(of: entry.text) { _, text in
+            .onChange(of: entry.text) { text in
                 revealWords(from: text)
             }
             .onAppear {

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,6 +42,8 @@ skills/
       api-surface.md                -- All public types and protocols
       features.md                   -- Feature implementation recipes
       customization.md              -- UI customization recipes
+  voice/
+    SKILL.md                        -- Voice calling integration
   troubleshooting/
     SKILL.md                        -- Issue triage decision tree
     reference/
@@ -51,12 +53,13 @@ skills/
   README.md                         -- This file
 ```
 
-### Three skills, split by user intent
+### Four skills, split by user intent
 
 | Skill | When it activates | What it does |
 |-------|-------------------|-------------|
 | **setup** | "Add the SDK", "integrate messaging", "set up in-app chat" | Guides initial integration step by step |
 | **features** | "Add push notifications", "customize colors", "replace views" | Routes to the right recipe, enforces example-first code gen |
+| **voice** | "Add voice", "add a call button", "voice modality" | Pulls open-source voice UI files and assets into the project (see note below) |
 | **troubleshooting** | "It's not working", "build error", "blank screen" | Triage checklist, then symptom-specific fixes |
 
 ## How It Works
@@ -70,6 +73,31 @@ The example app is in the public repo:
 
 When the example app is updated, the AI automatically gets the latest code on the
 next fetch. The skills themselves rarely need updating.
+
+### Voice skill -- what it adds to your project
+
+The **voice** skill works differently from the other skills. Instead of generating
+code based on examples, it pulls **open-source Swift source files and SVG image assets**
+directly from the public example app into your project:
+
+- **10 Swift files** added to a `Voice/` folder (voice control panel, audio visualizer,
+  transcript feed, modality observer, etc.)
+- **3 SVG image assets** added to your `Assets.xcassets/` (mute, unmute, end call icons)
+- **1 generated file** (`VoiceNavigationBarBuilder`) that wires the voice button into
+  the chat navigation bar
+
+These files are from the
+[`examples/Shared/Voice/`](https://github.com/Salesforce-Async-Messaging/messaging-in-app-ios/tree/master/examples/Shared/Voice)
+directory in the public repo. They are copied verbatim and become part of your app's
+source code -- you can customize them freely (colors, layout, button placement, etc.).
+
+Voice also requires the `SMIMultimediaCore` SPM package, which is a separate dependency
+from the main SDK. See the voice skill for details.
+
+By default, the voice button is added to the chat navigation bar. You can change where
+and how the button appears by modifying the `VoiceNavigationBarBuilder` or by using the
+**Navigation Bar Customization** feature in the features skill to control button
+placement across different screens.
 
 ### What the AI can help with
 
@@ -87,6 +115,11 @@ next fetch. The skills themselves rarely need updating.
 - "Hide the chat button outside business hours"
 - "Let users download a conversation transcript"
 - "Close a conversation programmatically"
+
+**Voice:**
+- "Add voice calling to the messaging experience"
+- "Add a voice button to the chat navigation bar"
+- "Enable voice modality in my messaging integration"
 
 **Customization:**
 - "Change the chat header color to match our brand"
@@ -108,6 +141,17 @@ next fetch. The skills themselves rarely need updating.
 - Create APNs certificates or push notification keys
 - Debug Salesforce-side configuration (routing, bot flows, agent availability)
 - Generate the `config.json` file (download it from the Salesforce org)
+
+## Disclaimer
+
+These skills are provided as a guide to help AI coding assistants generate correct
+integration code. **Results are not guaranteed.** AI-generated code should always be
+reviewed before merging into your project. Salesforce is not responsible for any issues
+arising from code produced by AI tools using these skills.
+
+Be aware that AI assistants may modify your source files, add new files, and change
+project configuration. Always review the changes an AI makes to your codebase before
+accepting them, and use version control so you can revert if needed.
 
 ## Resources
 

--- a/skills/features/SKILL.md
+++ b/skills/features/SKILL.md
@@ -8,7 +8,8 @@ description: >-
   management, conversation lists, templated URLs, auto-response, logging,
   locale mapping, delegate registration, ConversationClientDelegate, file attachments,
   allowed file types, attachment configuration, end chat, close conversation,
-  agent avatar, progress indicator, liquid glass, iOS 26, or conversation options.
+  agent avatar, progress indicator, liquid glass, iOS 26, conversation options,
+  voice, voice call, voice modality, multimedia, or modality.
 ---
 
 # Salesforce Messaging for In-App iOS SDK -- Features & Customization
@@ -116,6 +117,7 @@ Write only the code needed. Do not add anything the example does not demonstrate
 | End chat button / allow end chat | `reference/features.md` -- Conversation UI Options |
 | Agent avatar / progress indicators | `reference/features.md` -- Conversation UI Options |
 | iOS 26 liquid glass branding | `reference/features.md` -- Liquid Glass (iOS 26) |
+| Voice / voice call / voice modality | Use the **voice** skill (`voice/SKILL.md`) -- voice uses a different workflow |
 
 ### Customization
 | Request | Read this reference section |

--- a/skills/features/reference/api-surface.md
+++ b/skills/features/reference/api-surface.md
@@ -682,3 +682,87 @@ enum NavigationScreenType {
 SMIClientCore.Logging.level: LoggingLevel  // .debug or .none
 SMIClientUI.Logging.level: LoggingLevel    // .debug or .none
 ```
+
+---
+
+## Voice / Multimedia (SMIClientCore + SMIMultimediaCommon)
+
+Voice requires `import SMIMultimediaCommon` in addition to the standard imports.
+`SMIMultimediaCommon` is bundled with the `Swift-InAppMessaging` SPM package --
+no additional dependency is needed.
+
+### Modality (NS_TYPED_ENUM)
+
+```swift
+Modality.messaging
+Modality.voice
+```
+
+### ConversationClient -- Voice Methods
+
+```swift
+func changeModalities(_ modalities: [Modality])
+```
+
+Switches the conversation modality. Pass `[.voice]` to start voice or
+`[.messaging]` to return to text.
+
+### CoreClient -- Multimedia Property
+
+```swift
+var multimediaClient: MultimediaClientProtocol? { get }
+```
+
+### MultimediaClientProtocol
+
+```swift
+var currentSession: MultimediaSessionProtocol? { get }
+func add(delegate: MultimediaClientDelegate, queue: DispatchQueue?)
+```
+
+### MultimediaClientDelegate
+
+```swift
+func client(_ client: MultimediaClientProtocol, didUpdateSession session: MultimediaSessionProtocol)
+```
+
+### MultimediaSessionProtocol -- Key Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `state` | `MultimediaConnectionState` | Current session state |
+| `connectionDate` | `Date?` | When the session connected |
+| `displayName` | `String` | Agent display name |
+| `isMicrophoneMuted` | `Bool` | Whether local mic is muted |
+| `localParticipant` | `MultimediaParticipant?` | Local user participant |
+| `remoteParticipants` | `[MultimediaParticipant]` | Remote participants |
+
+### MultimediaSessionProtocol -- Key Methods
+
+```swift
+func join(completion: @escaping (Error?) -> Void)
+func leave(completion: @escaping (Error?) -> Void)
+func muteMicrophone()
+func unmuteMicrophone()
+```
+
+### MultimediaConnectionState
+
+```swift
+enum MultimediaConnectionState {
+    case initial
+    case connecting
+    case connected
+    case disconnecting
+    case disconnected
+}
+```
+
+### MultimediaParticipantOrigin
+
+```swift
+enum MultimediaParticipantOrigin {
+    case local
+    case remote
+}
+```

--- a/skills/rules/salesforce-messaging-sdk.md
+++ b/skills/rules/salesforce-messaging-sdk.md
@@ -39,6 +39,8 @@ memory -- always verify against either the fetched example or the api-surface re
 | Delegate registration | `Shared/Delegates/CoreDelegate/GlobalCoreDelegateHandler.swift` |
 | Conversation delegate | `Shared/Delegates/CoreDelegate/GlobalCoreDelegateHandler+ConversationClient.swift` |
 | Navigation bar | `Shared/Delegates/Providers/TestNavBarBuilder.swift` |
+| Voice UI files | `Shared/Voice/VoiceNavBarButtonHandler.swift` (+ 9 other files in `Voice/`) |
+| Voice nav bar wiring | `Shared/Delegates/Providers/TestNavBarBuilder.swift` |
 
 ## 2. Both imports are always required
 
@@ -49,6 +51,7 @@ import SMIClientUI
 
 `Configuration`, `ConversationEntry`, `TextMessage`, `ParticipantRole` are in `SMIClientCore`.
 `UIConfiguration`, `Interface`, `ChatFeedViewBuilder` are in `SMIClientUI`.
+Voice files additionally need `import SMIMultimediaCommon` (bundled with the SDK -- no extra dependency).
 
 ## 3. Never fabricate type names
 

--- a/skills/voice/SKILL.md
+++ b/skills/voice/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: salesforce-messaging-voice
+description: >-
+  Add voice calling to a Salesforce Messaging for In-App iOS SDK integration.
+  Use when the user mentions voice, voice call, voice modality, phone call,
+  audio call, multimedia, add a call button, or voice in the navigation bar.
+---
+
+# Salesforce Messaging for In-App iOS SDK -- Voice
+
+You add voice calling to an existing Messaging for In-App integration. This skill
+uses a **fetch-and-copy** pattern: you fetch tested, working voice UI files from the
+public example app and write them into the customer's project. You do NOT regenerate
+these files -- you copy them exactly as fetched.
+
+## Code Generation Rules
+
+These rules are mandatory for ALL code you generate or copy.
+
+1. **Fetch before writing.** Fetch every file listed in the file table below from the
+   public GitHub example app. Write each file exactly as fetched -- do NOT modify the
+   contents. The only file you generate yourself is the `NavigationBarBuilder` subclass.
+
+2. **Minimal changes to existing code.** All voice files go into their own `Voice/`
+   folder in the customer's project. The only changes to the customer's existing code
+   are wiring the builder into their `Interface` call and setting the `ConversationClient`.
+
+3. **Never invent type names.** Verify against the fetched files or
+   `reference/api-surface.md` in the features skill.
+
+4. **Imports.** Voice files use three SDK modules:
+   ```swift
+   import SMIClientCore
+   import SMIClientUI
+   import SMIMultimediaCommon
+   ```
+   `SMIMultimediaCommon` (protocols/types) is bundled with `Swift-InAppMessaging`.
+   `SMIMultimediaCore` (voice implementation) is a SEPARATE package -- see Prerequisites.
+
+5. **Line length limit.** Keep all lines under 160 characters. Break long lines.
+
+6. **Handle actor isolation.** If the project uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`
+   (Xcode 26 default):
+   - Mark `NavigationBarBuilder.init()` as `nonisolated`.
+
+## Prerequisites
+
+Confirm the user has all of these before writing any code:
+
+- **Existing messaging integration.** The SDK must already be added and the chat UI
+  must be working. If not, use the setup skill first.
+- **Voice plugin dependency.** The `SMIMultimediaCore` SPM package must be added to the
+  project. This is a SEPARATE package from `Swift-InAppMessaging` -- voice will not work
+  without it. The repository URL is:
+  `https://github.com/Salesforce-Async-Messaging/SMIMultimediaCore-iOS.swift`
+  The product to link is `SMIMultimediaCore`. The version MUST match the SDK version
+  (e.g. if `Swift-InAppMessaging` is 1.11.1, use `SMIMultimediaCore` 1.11.1).
+  Without this package, `CoreFactory.isMultimediaAvailable` returns `false` and the
+  voice modality will not function.
+  **This is a manual step the user must do in Xcode** (File > Add Package Dependencies).
+  You cannot add SPM packages programmatically. Ask the user to confirm they have added
+  it before proceeding. If unsure, check the project's `Package.resolved` or
+  `project.pbxproj` for `SMIMultimediaCore`.
+- **Voice enabled in Salesforce.** The embedded service deployment must have voice
+  enabled. If voice is not enabled, the voice button will never activate.
+- **Microphone permission.** `NSMicrophoneUsageDescription` must be set in `Info.plist`.
+  If missing, the app will crash when joining a voice session.
+
+## Step 1: Fetch and Copy Voice Files
+
+Fetch ALL 10 files listed below from the public GitHub example app. The base URL is:
+`https://raw.githubusercontent.com/Salesforce-Async-Messaging/messaging-in-app-ios/master/examples/Shared/Voice/`
+
+| File | URL suffix | Purpose |
+|------|-----------|---------|
+| `VoiceModalityObserver.swift` | `VoiceModalityObserver.swift` | Detects voice support via `ConversationClientDelegate` |
+| `VoiceNavBarButtonHandler.swift` | `VoiceNavBarButtonHandler.swift` | Manages nav bar voice button and sheet presentation |
+| `VoiceControlPanel.swift` | `VoiceControlPanel.swift` | Voice call UI: mute, end call, timer, live transcript |
+| `VoiceAudioRenderer.swift` | `VoiceAudioRenderer.swift` | Processes audio buffer data for visualization |
+| `VoiceAudioVisualizer.swift` | `VoiceAudioVisualizer.swift` | Animated audio level bars |
+| `VoiceTranscriptProvider.swift` | `VoiceTranscriptProvider.swift` | Listens for streaming tokens and final messages |
+| `VoiceTranscriptEntry.swift` | `VoiceTranscriptEntry.swift` | Model for a single transcript line |
+| `VoiceTranscriptFeedView.swift` | `VoiceTranscriptFeedView.swift` | Renders the live transcript feed |
+| `VoiceCircleIcon.swift` | `VoiceCircleIcon.swift` | Reusable circular button component |
+| `VoiceColors.swift` | `VoiceColors.swift` | Self-contained voice UI color palette |
+
+Do NOT fetch `VoiceSettings.swift` -- it depends on example-app-specific types
+(`SettingsStore`, `SettingsSection`, `SettingsToggle`) that do not exist in the
+customer's project.
+
+Write all 10 files into a new `Voice/` folder in the customer's project.
+Do NOT modify the file contents -- write them exactly as fetched.
+
+## Step 2: Fetch and Add Image Assets
+
+Fetch 3 SVG image assets and their `Contents.json` files. The base URL is:
+`https://raw.githubusercontent.com/Salesforce-Async-Messaging/messaging-in-app-ios/master/examples/MessagingUIExample/Assets.xcassets/`
+
+| Asset folder | Files to fetch |
+|-------------|---------------|
+| `actionEndVoice.imageset/` | `Contents.json`, `actionEndVoice.svg` |
+| `actionMute.imageset/` | `Contents.json`, `actionMute.svg` |
+| `actionUnmute.imageset/` | `Contents.json`, `actionUnmute.svg` |
+
+Write each imageset folder into the customer's `Assets.xcassets/` directory.
+
+If the fetch fails for SVG files, tell the customer to download them manually from:
+`https://github.com/Salesforce-Async-Messaging/messaging-in-app-ios/tree/master/examples/MessagingUIExample/Assets.xcassets`
+
+## Step 3: Create the NavigationBarBuilder
+
+This is the ONE file you generate (not copy). Create it in the `Voice/` folder.
+
+BEFORE generating this file, fetch the example that demonstrates the pattern:
+`https://raw.githubusercontent.com/Salesforce-Async-Messaging/messaging-in-app-ios/master/examples/Shared/Delegates/Providers/TestNavBarBuilder.swift`
+
+Study how `TestNavBarBuilder` uses `VoiceNavBarButtonHandler`:
+- It creates a `voiceHandler` property
+- It forwards the `ConversationClient` via a `client` property
+- In the `handleNavigation` closure, it calls `voiceHandler.addButton(to: navigationItem)`
+  when the screen is `.chatFeed`
+
+Generate this file in the customer's `Voice/` folder:
+
+```swift
+import SMIClientCore
+import SMIClientUI
+
+class VoiceNavigationBarBuilder: NavigationBarBuilder {
+    private let voiceHandler = VoiceNavBarButtonHandler()
+
+    var client: ConversationClient? {
+        didSet { voiceHandler.client = client }
+    }
+
+    override init() {
+        super.init()
+        self.handleNavigation = { [weak self] screenType, navigationItem in
+            if screenType == .chatFeed {
+                self?.voiceHandler.addButton(to: navigationItem)
+            }
+        }
+    }
+}
+```
+
+If the project uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Xcode 26), mark
+`init()` as `nonisolated`.
+
+**If the customer already has a `NavigationBarBuilder`:** Do NOT create a new one.
+Instead, add the voice handler to their existing builder:
+1. Add `private let voiceHandler = VoiceNavBarButtonHandler()` as a property.
+2. Add a `client` property that forwards to `voiceHandler.client`.
+3. In their existing `handleNavigation` closure, add:
+   ```swift
+   if screenType == .chatFeed {
+       voiceHandler.addButton(to: navigationItem)
+   }
+   ```
+
+## Step 4: Wire It Up
+
+Make exactly TWO edits to the customer's existing chat view:
+
+1. **Add a property** for the builder (skip if they already have a `NavigationBarBuilder`):
+   ```swift
+   private let voiceNavBuilder = VoiceNavigationBarBuilder()
+   ```
+
+2. **Pass it to Interface** and set the `ConversationClient`.
+
+   **IMPORTANT:** Use the SAME `UIConfiguration` object for both `Interface` and
+   `CoreFactory.create`. This ensures the factory returns the same `CoreClient`
+   instance the `Interface` uses internally -- the one with the multimedia extension.
+
+   The customer's code may already have a `UIConfiguration` stored in a variable with
+   a different name (e.g. `config`, `uiConfig`, `chatConfig`). Search for where
+   `UIConfiguration(` is created and reuse that existing variable -- do NOT create a
+   second one.
+
+   **SwiftUI:**
+   ```swift
+   let uiConfig = UIConfiguration(
+       configuration: config,
+       conversationId: conversationId
+   )
+   Interface(uiConfig, navigationBarBuilder: voiceNavBuilder)
+       .onAppear {
+           let client = CoreFactory.create(withConfig: uiConfig)
+               .conversationClient(with: conversationId)
+           voiceNavBuilder.client = client
+       }
+   ```
+
+   **UIKit (push):**
+   ```swift
+   let viewController = InterfaceViewController(uiConfig, navigationBarBuilder: voiceNavBuilder)
+   let client = CoreFactory.create(withConfig: uiConfig)
+       .conversationClient(with: conversationId)
+   voiceNavBuilder.client = client
+   navigationController?.pushViewController(viewController, animated: true)
+   ```
+
+   **UIKit (modal):**
+   ```swift
+   let viewController = ModalInterfaceViewController(uiConfig, navigationBarBuilder: voiceNavBuilder)
+   let client = CoreFactory.create(withConfig: uiConfig)
+       .conversationClient(with: conversationId)
+   voiceNavBuilder.client = client
+   present(viewController, animated: true)
+   ```
+
+## Step 5: Verify Info.plist
+
+Check that `NSMicrophoneUsageDescription` exists in the customer's `Info.plist`.
+If missing, add it:
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>Microphone access is needed for voice calls with support agents.</string>
+```
+
+## Step 6: Tell the Customer What Was Added
+
+After completing all steps, tell the customer:
+
+- A `Voice/` folder was added with 10 source files and a `VoiceNavigationBarBuilder`.
+- Three image assets (`actionEndVoice`, `actionMute`, `actionUnmute`) were added to
+  `Assets.xcassets`.
+- A voice button appears in the chat navigation bar when the Salesforce deployment
+  supports voice. The button auto-enables when voice becomes available and auto-disables
+  when it is not.
+- Tapping the button switches the conversation modality to voice and presents a voice
+  control panel with mute, end call, an elapsed time timer, and a live transcript.
+- They can customize the button placement by modifying `VoiceNavigationBarBuilder` or
+  moving the `voiceHandler.addButton(to:)` call to a different trigger.
+- They can customize the voice UI colors by editing `VoiceColors.swift`.
+
+## Self-Review
+
+Before presenting the result to the user, check:
+
+1. The `SMIMultimediaCore` package is listed as a dependency in the project?
+2. All 10 voice files were written to the `Voice/` folder exactly as fetched?
+3. The 3 image assets were written to `Assets.xcassets/`?
+4. The `VoiceNavigationBarBuilder` follows the pattern from `TestNavBarBuilder.swift`?
+5. Only TWO edits were made to the customer's existing code (property + Interface wiring)?
+6. The SAME `UIConfiguration` object is passed to both `Interface` and `CoreFactory.create`?
+7. `NSMicrophoneUsageDescription` is in `Info.plist`?
+8. If the project uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`: `init()` is `nonisolated`?
+9. No fetched voice files were modified?
+
+If any check fails, fix it before responding.
+
+## Common Mistakes
+
+- **Voice button appears but nothing happens when tapped.** The `SMIMultimediaCore` SPM
+  package is not linked. Without it, `multimediaClient` is `nil` and `changeModalities`
+  silently fails. Add `https://github.com/Salesforce-Async-Messaging/SMIMultimediaCore-iOS.swift`
+  as a package dependency with version matching the SDK version.
+- **Voice button never enables.** Voice is not enabled in the Salesforce org deployment.
+  The button relies on `didUpdateSupportedModalities` -- if the deployment does not
+  support voice, the delegate never fires with `.voice`.
+- **App crashes when joining voice.** `NSMicrophoneUsageDescription` is missing from
+  `Info.plist`.
+- **Import errors on `SMIMultimediaCommon`.** This module is bundled with the
+  `Swift-InAppMessaging` SPM package. If it cannot be found, the customer may need to
+  clean the build folder (Cmd+Shift+K) and rebuild.


### PR DESCRIPTION
Summary
Adds a new voice skill to the AI skills suite that guides coding assistants through adding voice calling to a customer's Messaging for In-App iOS integration.

Unlike the other skills which generate code based on examples, the voice skill uses a fetch-and-copy pattern -- it pulls 10 tested, open-source Swift files and 3 SVG image assets directly from the public example app into the customer's project, generates one NavigationBarBuilder to wire up a voice button in the chat nav bar, and makes two minimal edits to the customer's existing code.